### PR TITLE
add new exception rule in eslint config

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -27,7 +27,8 @@
     ],
     "react/react-in-jsx-scope": "off",
     "react/jsx-one-expression-per-line": "off",
-    "react/no-unescaped-entities": "off"
+    "react/no-unescaped-entities": "off",
+    "jsx-a11y/label-has-associated-control": "off"
   },
   "settings": {
     "import/resolver": {


### PR DESCRIPTION
this exception removes the requirement to insert an input into a label when creating a form. And therefore to keep only the obligation to link an htmlFor and an id