### PR TITLE
removed setup root script for postinstall

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,7 +31,7 @@ jobs:
           node-version: 16
 
       - name: Install Node.js dependencies
-        run: npm run setup
+        run: npm install
 
       - name: Run linters
         run: npm run lint

--- a/LISEZ-MOI.md
+++ b/LISEZ-MOI.md
@@ -8,12 +8,12 @@ Ce template est conçu pour servir de base à tous les projets (P2/P3) suivants 
 
 - Sur VSCode, installer les plugins **Prettier - Code formatter** et **ESLint** et les configurer
 - Cloner ce dépôt, se rendre à l'intérieur
-- Lancer la commande `npm run setup`
+- Lancer la commande `npm install`
 - _NB: Pour exécuter le backend, un fichier d'environnement avec les données de connexion d'une BdD valide est nécesaire. Un modèle se trouve dans `backend/.env.sample`_
 
 ### Liste des commandes et signification
 
-- `setup` : Initialisation du frontend et du backend ainsi que des outils
+- `migrate` : Exécute le script de création de la base de données
 - `dev` : Démarrage des deux serveurs (frontend + backend) dans un même terminal
 - `dev-front` : Démarrage d'un serveur React pour le frontend
 - `dev-back` : Démarrage d'un serveur Express pour le backend
@@ -31,19 +31,3 @@ Ce template est conçu pour servir de base à tous les projets (P2/P3) suivants 
 - _Prettier_ : Outil de "qualité de code" également, se concentre plus particulièrement sur le style du code
 - _Standard Airbnb_ : L'un des "standards" les plus connus, même s'il n'est pas officiellement lié à ES/JS
 - _Nodemon_ : Outil permettant de relancer un serveur à chaque fois qu'un des fichiers est modifié
-
-### Reste à faire
-
-Prettier:
-
-- corriger la config front/back pour qu'elle suive le même standard qu'ESLint
-
-Testing:
-
-- ajouter des tests unitaires sur le front et le back, avec les commandes associées
-
-Vérifications:
-
-- s'assurer que les principaux outils utilisés lors de la formation sont compatibles avec ce template
-- deploiements ? Compatible avec Netlify/Vercel/Heroku ?
-- fonctionnement avec yarn/pnpm

--- a/README.md
+++ b/README.md
@@ -9,12 +9,11 @@ It's pre-configured with a set of tools which'll help students produce industry-
 
 - In VSCode, install plugins **Prettier - Code formatter** and **ESLint** and configure them
 - Clone this repo, enter it
-- Run command `npm run setup`
+- Run command `npm install`
 - _NB: To launch the backend server, you'll need an environment file with database credentials. You'll find a template one in `backend/.env.sample`_
 
 ### Available Commands
 
-- `setup` : Initialization of frontend and backend, as well as all toolings
 - `migrate` : Run the database migration script
 - `dev` : Starts both servers (frontend + backend) in one terminal
 - `dev-front` : Starts the React frontend server

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "template-fullstack",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "license": "ISC",
       "devDependencies": {
         "concurrently": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -4,13 +4,14 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "setup": "npm i && husky install && npm --prefix ./frontend i && npm --prefix ./backend i",
+    "postinstall": "husky install && npm --prefix ./frontend i && npm --prefix ./backend i",
     "migrate": "cd backend/ && node migrate.js && cd ..",
     "dev": "concurrently -n front,back -c green,yellow -t \"HH:mm:ss\" -p \"{name} {time}\" \"npm --prefix ./frontend run dev\" \"npm --prefix ./backend run dev\"",
     "dev-front": "npm --prefix ./frontend run dev",
     "dev-back": "npm --prefix ./backend run dev",
     "lint": "npm --prefix ./frontend run lint && npm --prefix ./backend run lint",
-    "fix": "npm --prefix ./frontend run fix && npm --prefix ./backend run fix"
+    "fix": "npm --prefix ./frontend run fix && npm --prefix ./backend run fix",
+    "foo": "$0 -v"
   },
   "keywords": [],
   "author": "Wild Code School",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     "dev-front": "npm --prefix ./frontend run dev",
     "dev-back": "npm --prefix ./backend run dev",
     "lint": "npm --prefix ./frontend run lint && npm --prefix ./backend run lint",
-    "fix": "npm --prefix ./frontend run fix && npm --prefix ./backend run fix",
-    "foo": "$0 -v"
+    "fix": "npm --prefix ./frontend run fix && npm --prefix ./backend run fix"
   },
   "keywords": [],
   "author": "Wild Code School",


### PR DESCRIPTION
looks like postinstall hook works well to run install on sub front and back folder, instead of a custom setup script