### PR TITLE
170 server seedts issue on windows

### DIFF
--- a/template/server/bin/seed.ts
+++ b/template/server/bin/seed.ts
@@ -22,8 +22,8 @@ const seed = async () => {
 
     for (const filePath of filePaths) {
       const { default: SeederClass } = await import(
-				`file://${path.join(fixturesPath, filePath)}`
-			);
+	`file://${path.join(fixturesPath, filePath)}`
+      );
 
       const seeder = new SeederClass() as AbstractSeeder;
 

--- a/template/server/bin/seed.ts
+++ b/template/server/bin/seed.ts
@@ -22,8 +22,8 @@ const seed = async () => {
 
     for (const filePath of filePaths) {
       const { default: SeederClass } = await import(
-        path.join(fixturesPath, filePath)
-      );
+				`file://${path.join(fixturesPath, filePath)}`
+			);
 
       const seeder = new SeederClass() as AbstractSeeder;
 


### PR DESCRIPTION
updating fixtures file path import for windows to fix the following error on seed script execution : 

`Error filling the database: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:' Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:' at throwIfUnsupportedURLScheme (node:internal/modules/esm/load:217:11) at defaultLoad (node:internal/modules/esm/load:109:3) at nextLoad (node:internal/modules/esm/hooks:748:28) `