### PR TITLE
Add script biome format

### DIFF
--- a/template/biome.json
+++ b/template/biome.json
@@ -3,12 +3,7 @@
   "files": {
     "ignore": ["**/dist/*", "**/*.template.*", "**/tsconfig.json", "coverage"]
   },
-  "formatter": { 
-    "indentStyle": "space",
-    "ignore": [
-      "**/*.json"
-    ]
-  },
+  "formatter": { "indentStyle": "space" },
   "organizeImports": { "enabled": true },
   "linter": {
     "enabled": true,

--- a/template/biome.json
+++ b/template/biome.json
@@ -3,7 +3,12 @@
   "files": {
     "ignore": ["**/dist/*", "**/*.template.*", "**/tsconfig.json", "coverage"]
   },
-  "formatter": { "indentStyle": "space" },
+  "formatter": { 
+    "indentStyle": "space",
+    "ignore": [
+      "**/*.json"
+    ]
+  },
   "organizeImports": { "enabled": true },
   "linter": {
     "enabled": true,

--- a/template/client/src/main.tsx
+++ b/template/client/src/main.tsx
@@ -38,31 +38,30 @@ if (rootElement == null) {
 createRoot(rootElement).render(
   <StrictMode>
     <RouterProvider router={router} />
-  </StrictMode>
+  </StrictMode>,
 );
 
 /**
  * Helpful Notes:
- * 
+ *
  * 1. Adding More Routes:
  *    To add more pages to your app, first create a new component (e.g., About.tsx).
  *    Then, import that component above like this:
- * 
+ *
  *    import About from "./pages/About";
- * 
+ *
  *    Add a new route to the router:
- * 
+ *
  *      {
  *        path: "/about",
  *        element: <About />,  // Renders the About component
  *      }
- * 
+ *
  * 2. Try Nested Routes:
  *    For more complex applications, you can nest routes. This lets you have sub-pages within a main page.
  *    Documentation: https://reactrouter.com/en/main/start/tutorial#nested-routes
- * 
+ *
  * 3. Experiment with Dynamic Routes:
  *    You can create routes that take parameters (e.g., /users/:id).
  *    Documentation: https://reactrouter.com/en/main/start/tutorial#url-params-in-loaders
  */
-

--- a/template/package.json
+++ b/template/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "npm run build --workspaces --if-present",
     "check": "biome check --error-on-warnings --no-errors-on-unmatched --staged . && npm run check-types --workspaces --if-present",
-    "format":"biome format --write ./server/** ./client/**",
+    "check:fix":"biome check --write --error-on-warnings --no-errors-on-unmatched --staged .",
     "clean": "node ./bin/clean",
     "db:migrate": "npm run db:migrate --workspace=server",
     "db:seed": "npm run db:seed --workspace=server",

--- a/template/package.json
+++ b/template/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "build": "npm run build --workspaces --if-present",
     "check": "biome check --error-on-warnings --no-errors-on-unmatched --staged . && npm run check-types --workspaces --if-present",
+    "format":"biome format --write ./server/** ./client/**",
     "clean": "node ./bin/clean",
     "db:migrate": "npm run db:migrate --workspace=server",
     "db:seed": "npm run db:seed --workspace=server",

--- a/template/package.template.json
+++ b/template/package.template.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "npm run build --workspaces --if-present",
     "check": "biome check --error-on-warnings --no-errors-on-unmatched --staged . && npm run check-types --workspaces --if-present",
-    "format":"biome format --write ./server/** ./client/**",
+    "check:fix":"biome check --write --error-on-warnings --no-errors-on-unmatched --staged .",
     "clean": "node ./bin/clean",
     "db:migrate": "npm run db:migrate --workspace=server",
     "db:seed": "npm run db:seed --workspace=server",

--- a/template/package.template.json
+++ b/template/package.template.json
@@ -14,6 +14,7 @@
   "scripts": {
     "build": "npm run build --workspaces --if-present",
     "check": "biome check --error-on-warnings --no-errors-on-unmatched --staged . && npm run check-types --workspaces --if-present",
+    "format":"biome format --write ./server/** ./client/**",
     "clean": "node ./bin/clean",
     "db:migrate": "npm run db:migrate --workspace=server",
     "db:seed": "npm run db:seed --workspace=server",


### PR DESCRIPTION
## Introduce "format" script

The goal is to enable quick correction of files based on the configuration in the `biome.json` file.

The script operates on the root directories of `server` and `client`, targeting files with the following extensions: `{ts, tsx, js, jsx, css}`. Files with the `.json` extension are excluded.

**Note:** Files with the `.scss` extension are not yet supported by Biome (they are ignored without blocking the script).